### PR TITLE
Fix a 403 pip error during a docker-compose build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:4.4.7-wheezy
 
 # install data processing tools
-RUN apt-get update && apt-get -y install libpcap-dev gzip dtrx libtrace-tools python python-dev python-pip && pip install psycopg2 sqlalchemy
+RUN apt-get update && apt-get -y install libpcap-dev gzip dtrx libtrace-tools python python-dev python-pip && pip install --index-url=https://pypi.python.org/simple/ psycopg2 sqlalchemy
 
 # install tcptrace from source
 COPY tcptrace-src /tmp/tcptrace


### PR DESCRIPTION
The stacktrace error in the `pip.log` file was:
```
Downloading/unpacking sqlalchemy

  Getting page http://pypi.python.org/simple/sqlalchemy
  Could not fetch URL http://pypi.python.org/simple/sqlalchemy: HTTP Error 403: SSL is required
  Will skip URL http://pypi.python.org/simple/sqlalchemy when looking for download links for sqlalchemy
  Getting page http://pypi.python.org/simple/
  Could not fetch URL http://pypi.python.org/simple/: HTTP Error 403: SSL is required
  Will skip URL http://pypi.python.org/simple/ when looking for download links for sqlalchemy
  Cannot fetch index base URL http://pypi.python.org/simple/

...
```